### PR TITLE
Fix parsing s: functions

### DIFF
--- a/lib/Cargo.lock
+++ b/lib/Cargo.lock
@@ -21,10 +21,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "pretty_assertions"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+dependencies = [
+ "diff",
+ "yansi",
+]
 
 [[package]]
 name = "regex"
@@ -93,6 +109,13 @@ dependencies = [
 name = "vim-plugin-metadata"
 version = "0.1.0"
 dependencies = [
+ "pretty_assertions",
  "tree-sitter",
  "tree-sitter-vim",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -19,3 +19,6 @@ exclude = [
 [dependencies]
 tree-sitter = "0.23.0"
 tree-sitter-vim = "0.4.0"
+
+[dev-dependencies]
+pretty_assertions = "1.4.0"

--- a/py-bindings/src/lib.rs
+++ b/py-bindings/src/lib.rs
@@ -1,5 +1,5 @@
-use pyo3::prelude::*;
 use pyo3::exceptions::PyException;
+use pyo3::prelude::*;
 
 use vim_plugin_metadata::{VimModule, VimNode, VimParser};
 
@@ -20,11 +20,14 @@ mod py_vim_plugin_metadata {
             match self {
                 VimNode::StandaloneDocComment { ref text } => {
                     format!("StandaloneDocComment({text:?})")
-                },
+                }
                 VimNode::Function { ref name, ref doc } => {
-                    let doc_label = doc.as_ref().map(|text| format!("doc={text:?}")).unwrap_or("".to_string());
+                    let doc_label = doc
+                        .as_ref()
+                        .map(|text| format!("doc={text:?}"))
+                        .unwrap_or("".to_string());
                     format!("Function(name={name:?}{doc_label})")
-                },
+                }
             }
         }
     }
@@ -32,7 +35,9 @@ mod py_vim_plugin_metadata {
     impl From<super::VimNode> for VimNode {
         fn from(n: super::VimNode) -> VimNode {
             match n {
-                super::VimNode::StandaloneDocComment(text) => VimNode::StandaloneDocComment { text },
+                super::VimNode::StandaloneDocComment(text) => {
+                    VimNode::StandaloneDocComment { text }
+                }
                 super::VimNode::Function { name, doc } => VimNode::Function { name, doc },
             }
         }
@@ -54,7 +59,12 @@ mod py_vim_plugin_metadata {
         pub fn __repr__(&self) -> String {
             format!(
                 "VimModule(nodes=[{}])",
-                self.nodes.iter().map(|n| n.__repr__()).collect::<Vec<_>>().join(", "))
+                self.nodes
+                    .iter()
+                    .map(|n| n.__repr__())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )
         }
     }
 
@@ -82,7 +92,10 @@ mod py_vim_plugin_metadata {
         }
 
         pub fn parse_module(&mut self, code: &str) -> PyResult<VimModule> {
-            let module = self.rust_parser.parse_module(code).map_err(|err| PyException::new_err(format!("{err}")))?;
+            let module = self
+                .rust_parser
+                .parse_module(code)
+                .map_err(|err| PyException::new_err(format!("{err}")))?;
             Ok(module.into())
         }
     }


### PR DESCRIPTION
Find "scoped_identifier" nodes under func defs vs. just "identifier" ones, and warn/skip instead of panicking if no name is found.