### PR TITLE
Bump py-bindings to 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -104,7 +104,7 @@ dependencies = [
 
 [[package]]
 name = "py-vim-plugin-metadata"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "pyo3",
  "vim-plugin-metadata",

--- a/py-bindings/Cargo.toml
+++ b/py-bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "py-vim-plugin-metadata"
-version = "0.1.0"
+version = "0.1.1"
 readme = "README.md"
 authors = { workspace = true }
 edition = { workspace = true }


### PR DESCRIPTION
- Improved error handling
- Simplified with top-level .parse_module
- Forked better README instead of reusing rust one