### PR TITLE
gh-actions: fix handling of "py-v*" tags to be more consistent

### DIFF
--- a/.github/workflows/py-CI.yml
+++ b/.github/workflows/py-CI.yml
@@ -163,7 +163,7 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-    if: ${{ startsWith(github.ref, 'refs/tags/') }}
+    if: ${{ startsWith(github.ref, 'refs/tags/py-v') }}
     needs: [linux, musllinux, windows, macos, sdist]
     steps:
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
Avoids triggering "Release" if the overall workflow does get triggered
on a different tag ref.
