### PR TITLE
tooling: fix failing sdist job in py-CI

### DIFF
--- a/.github/workflows/py-CI.yml
+++ b/.github/workflows/py-CI.yml
@@ -145,7 +145,8 @@ jobs:
           path: py-bindings/dist
 
   sdist:
-    runs-on: ubuntu-latest
+    # Workaround for PyO3/maturin-action#291
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Build sdist


### PR DESCRIPTION
Run sdist on ubuntu-22.04 explicitly instead of ubuntu-latest.